### PR TITLE
[Resolves #1] 스냅샷 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,18 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    //querydsl
+    implementation 'com.querydsl:querydsl-jpa'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+
+    //mapstruct
+    implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+    annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
     //querydsl
     implementation 'com.querydsl:querydsl-jpa'
+    implementation 'org.projectlombok:lombok:1.18.22'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"

--- a/src/main/java/oncoding/concoder/ConcoderApplication.java
+++ b/src/main/java/oncoding/concoder/ConcoderApplication.java
@@ -2,7 +2,9 @@ package oncoding.concoder;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class ConcoderApplication {
 

--- a/src/main/java/oncoding/concoder/config/RedisConfig.java
+++ b/src/main/java/oncoding/concoder/config/RedisConfig.java
@@ -1,0 +1,62 @@
+package oncoding.concoder.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnection;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    
+    @Value("${spring.redis.host}")
+    private String host;
+    
+    @Value("${spring.redis.port}")
+    private int port;
+    
+    /*
+    Spring Data Redis는 Redis에 두 가지 접근 방식을 제공합니다.
+    하나는 RedisTemplate을 이용한 방식이며, 다른 하나는 RedisRepository를 이용한 방식
+    
+    두 방식 모두 Redis에 접근하기 위해서는 Redis 저장소와 연결하는 과정이 필요
+    이 과정을 위해 RedisConnectionFactory 인터페이스(LettuceConnectionFactory )를 사용
+    * */
+    @Bean //redisConnectionFactory 이름의 빈(역할)은 LettuceConnectionFactory(host, port)를 구현체로 선택한 것
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+    
+    /*
+    redisTemplate을 사용하여 Redis 저장소에 접근하기로 한다
+    RedisTemplate은 Redis 저장소에 오브젝트를 저장할 때 기본값으로 정의된 JdkSerializationRedisSerializer을 이용
+     */
+    @Bean
+    public RedisTemplate<String,Object> redisTemplate(){
+        RedisTemplate<String,Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+    
+    /*
+    대부분 레디스 key-value 는 문자열 위주이기 때문에 문자열에 특화된 템플릿을 제공
+    RedisTemplate 을 상속받은 클래스임.
+    StringRedisSerializer로 직렬화함
+     */
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(){
+        final StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
+        stringRedisTemplate.setKeySerializer(new StringRedisSerializer());
+        stringRedisTemplate.setValueSerializer(new StringRedisSerializer());
+        stringRedisTemplate.setConnectionFactory(redisConnectionFactory());
+        return stringRedisTemplate;
+    }
+    
+    
+
+}

--- a/src/main/java/oncoding/concoder/config/RedisConfig.java
+++ b/src/main/java/oncoding/concoder/config/RedisConfig.java
@@ -3,7 +3,6 @@ package oncoding.concoder.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.lettuce.LettuceConnection;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -18,22 +17,11 @@ public class RedisConfig {
     @Value("${spring.redis.port}")
     private int port;
     
-    /*
-    Spring Data Redis는 Redis에 두 가지 접근 방식을 제공합니다.
-    하나는 RedisTemplate을 이용한 방식이며, 다른 하나는 RedisRepository를 이용한 방식
-    
-    두 방식 모두 Redis에 접근하기 위해서는 Redis 저장소와 연결하는 과정이 필요
-    이 과정을 위해 RedisConnectionFactory 인터페이스(LettuceConnectionFactory )를 사용
-    * */
     @Bean //redisConnectionFactory 이름의 빈(역할)은 LettuceConnectionFactory(host, port)를 구현체로 선택한 것
     public LettuceConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(host, port);
     }
     
-    /*
-    redisTemplate을 사용하여 Redis 저장소에 접근하기로 한다
-    RedisTemplate은 Redis 저장소에 오브젝트를 저장할 때 기본값으로 정의된 JdkSerializationRedisSerializer을 이용
-     */
     @Bean
     public RedisTemplate<String,Object> redisTemplate(){
         RedisTemplate<String,Object> redisTemplate = new RedisTemplate<>();
@@ -43,11 +31,6 @@ public class RedisConfig {
         return redisTemplate;
     }
     
-    /*
-    대부분 레디스 key-value 는 문자열 위주이기 때문에 문자열에 특화된 템플릿을 제공
-    RedisTemplate 을 상속받은 클래스임.
-    StringRedisSerializer로 직렬화함
-     */
     @Bean
     public StringRedisTemplate stringRedisTemplate(){
         final StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
@@ -57,6 +40,4 @@ public class RedisConfig {
         return stringRedisTemplate;
     }
     
-    
-
 }

--- a/src/main/java/oncoding/concoder/controller/SnapshotController.java
+++ b/src/main/java/oncoding/concoder/controller/SnapshotController.java
@@ -3,9 +3,7 @@ package oncoding.concoder.controller;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import oncoding.concoder.dto.SnapshotDto;
-import oncoding.concoder.dto.SnapshotDto.GetAll;
 import oncoding.concoder.mapper.SnapshotDtoMapper;
 import oncoding.concoder.service.SnapshotService;
 import org.springframework.http.MediaType;
@@ -30,10 +28,9 @@ public class SnapshotController {
      * 전체 조회
      * @return
      */
-    @SneakyThrows
     @GetMapping
-    public Map<String, GetAll> getSnapshots(){
-        return mapper.toSnapshotGetAllMap(service.getSnapshots());
+    public Map<String, SnapshotDto.AllResponse> getSnapshots(){
+        return mapper.toSnapshotAllMap(service.getSnapshots());
     }
 
     /**
@@ -41,10 +38,9 @@ public class SnapshotController {
      * @param
      * @return
      */
-    @SneakyThrows
     @GetMapping("/{snapshotId}")
-    public GetAll getSnapshot(@PathVariable UUID snapshotId){
-        return mapper.toSnapshotDtoGetAll(service.getSnapshot(snapshotId));
+    public SnapshotDto.AllResponse getSnapshot(@PathVariable UUID snapshotId){
+        return mapper.toSnapshotDtoAll(service.getSnapshot(snapshotId));
     }
 
     /**
@@ -52,10 +48,9 @@ public class SnapshotController {
      * @param in
      * @return
      */
-    @SneakyThrows
     @PostMapping
-    public GetAll createSnapshot(@RequestBody SnapshotDto.Add in){
-        return mapper.toSnapshotDtoGetAll(service.createSnapshot(mapper.toSnapshot(in)));
+    public SnapshotDto.AllResponse createSnapshot(@RequestBody SnapshotDto.CreateRequest in){
+        return mapper.toSnapshotDtoAll(service.createSnapshot(mapper.toSnapshot(in)));
     }
 
 
@@ -64,12 +59,11 @@ public class SnapshotController {
      * @param
      * @return
      */
-    @SneakyThrows
     @PutMapping
-    public GetAll modifySnapshot(@RequestBody SnapshotDto.Modify in){
+    public SnapshotDto.AllResponse modifySnapshot(@RequestBody SnapshotDto.ModifyRequest in){
         UUID id = in.getId();
         String memo = in.getMemo();
-        return mapper.toSnapshotDtoGetAll(service.modifySnapshot(id, memo));
+        return mapper.toSnapshotDtoAll(service.modifySnapshot(id, memo));
     }
 
 
@@ -78,7 +72,6 @@ public class SnapshotController {
      * @param
      * @return
      */
-    @SneakyThrows
     @DeleteMapping("/{snapshotId}")
     public void deleteSnapshot(@PathVariable UUID snapshotId){
         service.deleteSnapshot(snapshotId);

--- a/src/main/java/oncoding/concoder/controller/SnapshotController.java
+++ b/src/main/java/oncoding/concoder/controller/SnapshotController.java
@@ -1,0 +1,88 @@
+package oncoding.concoder.controller;
+
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import oncoding.concoder.dto.SnapshotDto;
+import oncoding.concoder.dto.SnapshotDto.GetAll;
+import oncoding.concoder.mapper.SnapshotDtoMapper;
+import oncoding.concoder.service.SnapshotService;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping(value = "/snapshots", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
+@RequiredArgsConstructor
+public class SnapshotController {
+    
+    private final SnapshotService service;
+    private final SnapshotDtoMapper mapper;
+    
+    /**
+     * 전체 조회
+     * @return
+     */
+    @SneakyThrows
+    @GetMapping
+    public List<GetAll> getSnapshots(){
+        return mapper.toSnapshotGetAllList(service.getSnapshots());
+    }
+    
+    /**
+     * 단건 조회
+     * @param
+     * @return
+     */
+    @SneakyThrows
+    @GetMapping("/{snapshotId}")
+    public GetAll getSnapshot(@PathVariable UUID snapshotId){
+        return mapper.toSnapshotDtoGetAll(service.getSnapshot(snapshotId));
+    }
+    
+    /**
+     * 새로운 스냅샷 저장
+     * @param in
+     * @return
+     */
+    @SneakyThrows
+    @PostMapping
+    public GetAll createSnapshot(SnapshotDto.Add in){
+        return mapper.toSnapshotDtoGetAll(service.createSnapshot(mapper.toSnapshot(in)));
+    }
+    
+    
+    /**
+     * 수정
+     * @param
+     * @return
+     */
+    @SneakyThrows
+    @PutMapping
+    public GetAll modifySnapshot(SnapshotDto.Modify in){
+        UUID id = in.getId();
+        String memo = in.getMemo();
+        return mapper.toSnapshotDtoGetAll(service.modifySnapshot(id, memo));
+    }
+    
+    
+    /**
+     * 삭제
+     * @param
+     * @return
+     */
+    @SneakyThrows
+    @DeleteMapping("/{snapshotId}")
+    public void deleteSnapshot(@PathVariable UUID snapshotId){
+        service.deleteSnapshot(snapshotId);
+    }
+    
+    
+}

--- a/src/main/java/oncoding/concoder/controller/SnapshotController.java
+++ b/src/main/java/oncoding/concoder/controller/SnapshotController.java
@@ -1,7 +1,6 @@
 package oncoding.concoder.controller;
 
-
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
@@ -15,6 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,20 +22,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 public class SnapshotController {
-    
+
     private final SnapshotService service;
     private final SnapshotDtoMapper mapper;
-    
+
     /**
      * 전체 조회
      * @return
      */
     @SneakyThrows
     @GetMapping
-    public List<GetAll> getSnapshots(){
-        return mapper.toSnapshotGetAllList(service.getSnapshots());
+    public Map<String, GetAll> getSnapshots(){
+        return mapper.toSnapshotGetAllMap(service.getSnapshots());
     }
-    
+
     /**
      * 단건 조회
      * @param
@@ -46,7 +46,7 @@ public class SnapshotController {
     public GetAll getSnapshot(@PathVariable UUID snapshotId){
         return mapper.toSnapshotDtoGetAll(service.getSnapshot(snapshotId));
     }
-    
+
     /**
      * 새로운 스냅샷 저장
      * @param in
@@ -54,11 +54,11 @@ public class SnapshotController {
      */
     @SneakyThrows
     @PostMapping
-    public GetAll createSnapshot(SnapshotDto.Add in){
+    public GetAll createSnapshot(@RequestBody SnapshotDto.Add in){
         return mapper.toSnapshotDtoGetAll(service.createSnapshot(mapper.toSnapshot(in)));
     }
-    
-    
+
+
     /**
      * 수정
      * @param
@@ -66,13 +66,13 @@ public class SnapshotController {
      */
     @SneakyThrows
     @PutMapping
-    public GetAll modifySnapshot(SnapshotDto.Modify in){
+    public GetAll modifySnapshot(@RequestBody SnapshotDto.Modify in){
         UUID id = in.getId();
         String memo = in.getMemo();
         return mapper.toSnapshotDtoGetAll(service.modifySnapshot(id, memo));
     }
-    
-    
+
+
     /**
      * 삭제
      * @param
@@ -83,6 +83,6 @@ public class SnapshotController {
     public void deleteSnapshot(@PathVariable UUID snapshotId){
         service.deleteSnapshot(snapshotId);
     }
-    
-    
+
+
 }

--- a/src/main/java/oncoding/concoder/dto/SnapshotDto.java
+++ b/src/main/java/oncoding/concoder/dto/SnapshotDto.java
@@ -15,7 +15,7 @@ public class SnapshotDto {
     @Builder
     @ToString
     @AllArgsConstructor
-    public static class GetAll{
+    public static class AllResponse{
         
         private UUID id;
     
@@ -35,7 +35,7 @@ public class SnapshotDto {
     @Builder
     @ToString
     @AllArgsConstructor
-    public static class Add{
+    public static class CreateRequest{
     
         private String memo;
     
@@ -48,7 +48,7 @@ public class SnapshotDto {
     @Builder
     @ToString
     @AllArgsConstructor
-    public static class Modify{
+    public static class ModifyRequest{
     
         private UUID id;
         

--- a/src/main/java/oncoding/concoder/dto/SnapshotDto.java
+++ b/src/main/java/oncoding/concoder/dto/SnapshotDto.java
@@ -1,0 +1,58 @@
+package oncoding.concoder.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+public class SnapshotDto {
+    
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @AllArgsConstructor
+    public static class GetAll{
+        
+        private UUID id;
+    
+        private String memo;
+    
+        private String content;
+     
+        private LocalDateTime createdDate;
+        
+        private LocalDateTime modifiedDate;
+        
+    }
+    
+    
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @AllArgsConstructor
+    public static class Add{
+    
+        private String memo;
+    
+        private String content;
+        
+    }
+    
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @AllArgsConstructor
+    public static class Modify{
+    
+        private UUID id;
+        
+        private String memo;
+    }
+
+}

--- a/src/main/java/oncoding/concoder/mapper/SnapshotDtoMapper.java
+++ b/src/main/java/oncoding/concoder/mapper/SnapshotDtoMapper.java
@@ -1,0 +1,22 @@
+package oncoding.concoder.mapper;
+
+import java.util.List;
+import oncoding.concoder.dto.SnapshotDto;
+import oncoding.concoder.dto.SnapshotDto.GetAll;
+import oncoding.concoder.model.Snapshot;
+import org.mapstruct.Builder;
+import org.mapstruct.Mapper;
+
+@Mapper(
+    implementationName = "SnapshotDtoMapperImpl",
+    builder=@Builder(disableBuilder = true),
+    componentModel = "spring"
+)
+public abstract class SnapshotDtoMapper {
+
+    public abstract Snapshot toSnapshot(SnapshotDto.Add in);
+    public abstract Snapshot toSnapshot(SnapshotDto.Modify in);
+    public abstract SnapshotDto.GetAll toSnapshotDtoGetAll(Snapshot snapshot);
+    
+    public abstract List<GetAll> toSnapshotGetAllList(List<Snapshot> in);
+}

--- a/src/main/java/oncoding/concoder/mapper/SnapshotDtoMapper.java
+++ b/src/main/java/oncoding/concoder/mapper/SnapshotDtoMapper.java
@@ -1,6 +1,7 @@
 package oncoding.concoder.mapper;
 
 import java.util.List;
+import java.util.Map;
 import oncoding.concoder.dto.SnapshotDto;
 import oncoding.concoder.dto.SnapshotDto.GetAll;
 import oncoding.concoder.model.Snapshot;
@@ -19,4 +20,5 @@ public abstract class SnapshotDtoMapper {
     public abstract SnapshotDto.GetAll toSnapshotDtoGetAll(Snapshot snapshot);
     
     public abstract List<GetAll> toSnapshotGetAllList(List<Snapshot> in);
+    public abstract Map<String,GetAll> toSnapshotGetAllMap(Map<String,Snapshot> in);
 }

--- a/src/main/java/oncoding/concoder/mapper/SnapshotDtoMapper.java
+++ b/src/main/java/oncoding/concoder/mapper/SnapshotDtoMapper.java
@@ -3,7 +3,6 @@ package oncoding.concoder.mapper;
 import java.util.List;
 import java.util.Map;
 import oncoding.concoder.dto.SnapshotDto;
-import oncoding.concoder.dto.SnapshotDto.GetAll;
 import oncoding.concoder.model.Snapshot;
 import org.mapstruct.Builder;
 import org.mapstruct.Mapper;
@@ -15,10 +14,10 @@ import org.mapstruct.Mapper;
 )
 public abstract class SnapshotDtoMapper {
 
-    public abstract Snapshot toSnapshot(SnapshotDto.Add in);
-    public abstract Snapshot toSnapshot(SnapshotDto.Modify in);
-    public abstract SnapshotDto.GetAll toSnapshotDtoGetAll(Snapshot snapshot);
+    public abstract Snapshot toSnapshot(SnapshotDto.CreateRequest in);
+    public abstract Snapshot toSnapshot(SnapshotDto.ModifyRequest in);
+    public abstract SnapshotDto.AllResponse toSnapshotDtoAll(Snapshot snapshot);
     
-    public abstract List<GetAll> toSnapshotGetAllList(List<Snapshot> in);
-    public abstract Map<String,GetAll> toSnapshotGetAllMap(Map<String,Snapshot> in);
+    public abstract List<SnapshotDto.AllResponse> toSnapshotAllList(List<Snapshot> in);
+    public abstract Map<String,SnapshotDto.AllResponse> toSnapshotAllMap(Map<String,Snapshot> in);
 }

--- a/src/main/java/oncoding/concoder/model/Snapshot.java
+++ b/src/main/java/oncoding/concoder/model/Snapshot.java
@@ -1,0 +1,35 @@
+package oncoding.concoder.model;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Snapshot extends JpaBaseEntity {
+    
+    @CreatedDate
+    @Column(updatable=false, nullable = false)
+    private LocalDateTime createdDate;
+    
+    @Column
+    @NotNull
+    private String memo;
+    
+    @Column
+    @NotNull
+    private String content;
+}

--- a/src/main/java/oncoding/concoder/model/Snapshot.java
+++ b/src/main/java/oncoding/concoder/model/Snapshot.java
@@ -1,10 +1,12 @@
 package oncoding.concoder.model;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
+import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -20,15 +22,16 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
-public class Snapshot extends JpaBaseEntity {
+public class Snapshot implements Serializable {
     
-    @CreatedDate
+    private static final long serialVersionUID = 2148687123052233925L;
+    
+    @Id
+    private UUID id;
+    
     @Column(updatable=false, nullable = false)
     private LocalDateTime createdDate;
     
-    
-    @LastModifiedDate
     @Column(updatable=false, nullable = false)
     private LocalDateTime modifiedDate;
     
@@ -41,8 +44,20 @@ public class Snapshot extends JpaBaseEntity {
     private String content;
     
     
+    public void setId(UUID id){
+        this.id = id;
+    }
+    
     public void setMemo(String memo){
         this.memo = memo;
+    }
+    
+    public void setCreatedDate(LocalDateTime time){
+        this.createdDate = time;
+    }
+    
+    public void setModifiedDate(LocalDateTime time){
+        this.modifiedDate = time;
     }
     
 }

--- a/src/main/java/oncoding/concoder/model/Snapshot.java
+++ b/src/main/java/oncoding/concoder/model/Snapshot.java
@@ -5,22 +5,16 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Snapshot implements Serializable {
     
@@ -43,6 +37,15 @@ public class Snapshot implements Serializable {
     @NotNull
     private String content;
     
+    @Builder
+    public Snapshot(UUID id, LocalDateTime createdDate, LocalDateTime modifiedDate, String memo,
+        String content) {
+        this.id = id;
+        this.createdDate = createdDate;
+        this.modifiedDate = modifiedDate;
+        this.memo = memo;
+        this.content = content;
+    }
     
     public void setId(UUID id){
         this.id = id;

--- a/src/main/java/oncoding/concoder/model/Snapshot.java
+++ b/src/main/java/oncoding/concoder/model/Snapshot.java
@@ -1,6 +1,7 @@
 package oncoding.concoder.model;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
@@ -11,6 +12,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
@@ -25,6 +27,11 @@ public class Snapshot extends JpaBaseEntity {
     @Column(updatable=false, nullable = false)
     private LocalDateTime createdDate;
     
+    
+    @LastModifiedDate
+    @Column(updatable=false, nullable = false)
+    private LocalDateTime modifiedDate;
+    
     @Column
     @NotNull
     private String memo;
@@ -32,4 +39,10 @@ public class Snapshot extends JpaBaseEntity {
     @Column
     @NotNull
     private String content;
+    
+    
+    public void setMemo(String memo){
+        this.memo = memo;
+    }
+    
 }

--- a/src/main/java/oncoding/concoder/repository/SnapshotRepository.java
+++ b/src/main/java/oncoding/concoder/repository/SnapshotRepository.java
@@ -1,0 +1,11 @@
+package oncoding.concoder.repository;
+
+import java.util.UUID;
+import oncoding.concoder.model.Snapshot;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+
+public interface SnapshotRepository extends JpaRepository<Snapshot, UUID>,
+    QuerydslPredicateExecutor<Snapshot> {
+
+}

--- a/src/main/java/oncoding/concoder/service/SnapshotService.java
+++ b/src/main/java/oncoding/concoder/service/SnapshotService.java
@@ -1,0 +1,74 @@
+package oncoding.concoder.service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import oncoding.concoder.model.Snapshot;
+import oncoding.concoder.repository.SnapshotRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SnapshotService {
+    
+    private final SnapshotRepository repository;
+    
+    /**
+     * 목록 조회
+     * @return 현재 snpshot 리스트
+     */
+    public List<Snapshot> getSnapshots(){
+        return repository.findAll();
+    }
+    
+    /**
+     * 단건 조회
+     *
+     * @return 현재 snpshot 리스트
+     */
+    public Snapshot getSnapshot(UUID id){
+        return repository.findById(id).orElse(null);
+    }
+    
+    /**
+     * snapshot 생성
+     * @param snapshot
+     * @return
+     */
+    public Snapshot createSnapshot(Snapshot snapshot){
+        return repository.save(snapshot);
+    }
+    
+    /**
+     * 스냅샷 수정 - 메모만 수정 가능
+     * @param id
+     * @param memo
+     * @return
+     */
+    public Snapshot modifySnapshot(UUID id, String memo){
+        
+        Snapshot existing = repository.findById(id).orElse(null);
+        existing.setMemo(memo);
+        
+        return repository.save(existing);
+        
+    }
+    
+    /**
+     * 스냅샷 단건 삭제
+     */
+    public void deleteSnapshot(UUID id){
+        repository.deleteById(id);
+    }
+    
+    /**
+     * 스냅샷 전체 삭제
+     */
+    public void deleteSnapshots(){
+        repository.deleteAll();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,4 @@
-
+spring:
+  redis:
+    host: localhost
+    port: 6379

--- a/src/test/java/oncoding/concoder/config/RedisBasicTest.java
+++ b/src/test/java/oncoding/concoder/config/RedisBasicTest.java
@@ -1,9 +1,7 @@
-package oncoding.concoder.service;
+package oncoding.concoder.config;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.concurrent.TimeUnit;
-import javax.persistence.Entity;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,17 +10,8 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.test.context.ActiveProfiles;
-
-/*
-@SpringBootTest
-@SpringBootApplication 애노테이션을 찾아가서 이 애노테이션부터 시작하는 모든 빈을 스캔하는 것이다.
-그리고 스캔한 모든 빈을 테스트용 애플리케이션에 다 등록해주는 것
- */
 
 @SpringBootTest
-//@ActiveProfiles("test")
-//@AutoConfigureTestDatabase(replace = Replace.AUTO_CONFIGURED) // 실제 DB 사용하고 싶을때 NONE 사용
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 public class RedisBasicTest {
     
@@ -95,8 +84,7 @@ public class RedisBasicTest {
         final Boolean expire = redisTemplate.expire(key, 5, TimeUnit.SECONDS);
         Thread.sleep(6000);
         final String s = valueOperations.get(key);
-//        assertThat(expire).isTrue();
-//        assertThat(s).isNull();
+
     }
     
 }

--- a/src/test/java/oncoding/concoder/config/RedisBasicTest.java
+++ b/src/test/java/oncoding/concoder/config/RedisBasicTest.java
@@ -1,6 +1,9 @@
 package oncoding.concoder.config;
 
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -16,10 +19,13 @@ import org.springframework.data.redis.core.ValueOperations;
 public class RedisBasicTest {
     
     @Autowired
-    RedisTemplate<String, String> redisTemplate;
+    RedisTemplate<String, String> redisTemplate1;
+    @Autowired
+    RedisTemplate<String, Object> redisTemplate;
     
  
-    public static class RedisUserDto{
+    
+    public static class RedisUserDto implements Serializable {
         private String name;
         private String password;
         
@@ -49,25 +55,12 @@ public class RedisBasicTest {
     void redisConnectionTest() {
         final String key = "a";
         final String data = "1";
-        
-        final ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+
+        final ValueOperations<String, String> valueOperations = redisTemplate1.opsForValue();
         valueOperations.set(key, data);
-        
+
         final String s = valueOperations.get(key);
         Assertions.assertThat(s).isEqualTo(data);
-    }
-    
-    @Test
-    void redisInsertObject(){
-        RedisUserDto redisUserDto = new RedisUserDto("kenux", "password");
-        
-        final ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-        valueOperations.set(redisUserDto.getName(), String.valueOf(redisUserDto));
-    
-        final String result = valueOperations.get(redisUserDto.getName());
-
-        System.out.println("result = " + result);
-    
     }
     
     /**
@@ -79,7 +72,7 @@ public class RedisBasicTest {
         final String key = "a";
         final String data = "1";
         
-        final ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        final ValueOperations<String, String> valueOperations = redisTemplate1.opsForValue();
         valueOperations.set(key, data);
         final Boolean expire = redisTemplate.expire(key, 5, TimeUnit.SECONDS);
         Thread.sleep(6000);

--- a/src/test/java/oncoding/concoder/service/RedisBasicTest.java
+++ b/src/test/java/oncoding/concoder/service/RedisBasicTest.java
@@ -1,0 +1,102 @@
+package oncoding.concoder.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.concurrent.TimeUnit;
+import javax.persistence.Entity;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.context.ActiveProfiles;
+
+/*
+@SpringBootTest
+@SpringBootApplication 애노테이션을 찾아가서 이 애노테이션부터 시작하는 모든 빈을 스캔하는 것이다.
+그리고 스캔한 모든 빈을 테스트용 애플리케이션에 다 등록해주는 것
+ */
+
+@SpringBootTest
+//@ActiveProfiles("test")
+//@AutoConfigureTestDatabase(replace = Replace.AUTO_CONFIGURED) // 실제 DB 사용하고 싶을때 NONE 사용
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+public class RedisBasicTest {
+    
+    @Autowired
+    RedisTemplate<String, String> redisTemplate;
+    
+ 
+    public static class RedisUserDto{
+        private String name;
+        private String password;
+        
+        public RedisUserDto(String name, String password){
+            this.name = name;
+            this.password = password;
+        }
+    
+        public RedisUserDto() {
+        
+        }
+    
+        public String getName(){
+            return this.name;
+        }
+
+        public String getPassword(){
+            return this.password;
+        }
+        
+    }
+    
+    /**
+     * 단순 연결 테스트 -  key와 value 삽입
+     */
+    @Test
+    void redisConnectionTest() {
+        final String key = "a";
+        final String data = "1";
+        
+        final ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(key, data);
+        
+        final String s = valueOperations.get(key);
+        Assertions.assertThat(s).isEqualTo(data);
+    }
+    
+    @Test
+    void redisInsertObject(){
+        RedisUserDto redisUserDto = new RedisUserDto("kenux", "password");
+        
+        final ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(redisUserDto.getName(), String.valueOf(redisUserDto));
+    
+        final String result = valueOperations.get(redisUserDto.getName());
+
+        System.out.println("result = " + result);
+    
+    }
+    
+    /**
+     * 위 코드 redis에 삽입한 아이템에 대해서 5초의 expire time을 설정하고, 5초가 지난 후에 redis에서 해당 키가 조회되는지 테스트하는 코드
+     * @throws InterruptedException
+     */
+    @Test
+    void redisExpireTest() throws InterruptedException {
+        final String key = "a";
+        final String data = "1";
+        
+        final ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(key, data);
+        final Boolean expire = redisTemplate.expire(key, 5, TimeUnit.SECONDS);
+        Thread.sleep(6000);
+        final String s = valueOperations.get(key);
+//        assertThat(expire).isTrue();
+//        assertThat(s).isNull();
+    }
+    
+}

--- a/src/test/java/oncoding/concoder/service/SnapshotServiceTest.java
+++ b/src/test/java/oncoding/concoder/service/SnapshotServiceTest.java
@@ -1,0 +1,80 @@
+package oncoding.concoder.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.UUID;
+import oncoding.concoder.model.Snapshot;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@SpringBootTest
+class SnapshotServiceTest {
+    
+    @Autowired
+    SnapshotService service;
+    
+    @Autowired
+    RedisTemplate<String, Object> redisTemplate;
+    
+    
+    @Test
+    void redis_전체_조회(){
+    
+        Snapshot snapshot = Snapshot.builder().memo("memo").content("hi").build();
+        snapshot.setId(UUID.randomUUID());
+        
+        HashOperations hashOperations = redisTemplate.opsForHash();
+        hashOperations.put("Snapshot",snapshot.getId().toString(),snapshot);
+        
+        Map<String,Snapshot> map = service.getSnapshots();
+        assertTrue((map.get("332a90fb-c02f-4b35-b273-b66eab7e6140").getMemo()).equals("modified_memo"));
+        
+    }
+    
+    
+    @Test
+    void redis_단건_조회(){
+        Snapshot snapshot = service.getSnapshot(UUID.fromString("332a90fb-c02f-4b35-b273-b66eab7e6140"));
+        assertTrue(snapshot != null);
+        assertTrue(snapshot.getMemo().equals("memo"));
+        assertTrue(snapshot.getContent().equals("hi"));
+    }
+    
+    @Test
+    void redis_생성_및_저장(){
+    
+        Snapshot snapshot = Snapshot.builder().memo("new_memo").content("new_content").build();
+        Snapshot newSnapshot = service.createSnapshot(snapshot);
+        
+        assertTrue(newSnapshot.getMemo().equals("new_memo"));
+        assertTrue(snapshot.getContent().equals("new_content"));
+        
+    }
+    
+    @Test
+    void redis_메모_수정(){
+        Snapshot shot = service.getSnapshot(UUID.fromString("332a90fb-c02f-4b35-b273-b66eab7e6140"));
+        assertTrue(shot.getMemo().equals("memo"));
+        Snapshot newshot = service.modifySnapshot(UUID.fromString("332a90fb-c02f-4b35-b273-b66eab7e6140"),"modified_memo");
+       assertTrue(newshot.getMemo().equals("modified_memo"));
+    
+    }
+    
+    
+    @Test
+    void redis_단건_삭제(){
+        
+        //[068d718b-4a80-4bb5-96bf-fec395e1d5b3, a8296418-127a-4839-80e7-6697f730cc5a, c95224ea-b7cc-4ded-b23d-09c5670f5145, 99f6168a-1bf0-46b2-bb70-dad04fdc0421, 030434af-2eab-4b95-af6e-1abbc872d282, ebe37cef-4795-41e7-8b16-7fa169728898, 3412bd33-950c-4c68-9db6-a955987e63a3, bf937828-49fa-4a3d-ae83-8b6256939ae3, ed9365b1-9899-4c28-b7cc-f6c83354fb30, f4351de8-8719-49f4-99c5-b2a2989057df, 10361e27-794e-4dcc-b17d-4ebccdedb146, 332a90fb-c02f-4b35-b273-b66eab7e6140, 513fb53d-b6e1-4bbd-bb59-3067150e15dc, b3477404-557e-44c0-859f-201912c78d33, 4c3fef4a-2e04-4e1b-86ca-fff34b8e67bc, 348cb38a-6640-4a72-a7cd-9c769ec1f6e1, 740def97-106b-4446-9632-df74b03bbc06]
+    
+        assertTrue(service.getSnapshot(UUID.fromString("068d718b-4a80-4bb5-96bf-fec395e1d5b3"))!= null);
+        service.deleteSnapshot(UUID.fromString("068d718b-4a80-4bb5-96bf-fec395e1d5b3"));
+        assertTrue(service.getSnapshot(UUID.fromString("068d718b-4a80-4bb5-96bf-fec395e1d5b3"))== null);
+    
+    }
+    
+    
+}

--- a/src/test/java/oncoding/concoder/service/SnapshotServiceTest.java
+++ b/src/test/java/oncoding/concoder/service/SnapshotServiceTest.java
@@ -22,6 +22,12 @@ class SnapshotServiceTest {
     
     
     @Test
+    void Redis_빌더(){
+        Snapshot snapshot = Snapshot.builder().memo("memo").content("hi").build();
+    
+    }
+    
+    @Test
     void redis_전체_조회(){
     
         Snapshot snapshot = Snapshot.builder().memo("memo").content("hi").build();
@@ -60,16 +66,14 @@ class SnapshotServiceTest {
         Snapshot shot = service.getSnapshot(UUID.fromString("332a90fb-c02f-4b35-b273-b66eab7e6140"));
         assertTrue(shot.getMemo().equals("memo"));
         Snapshot newshot = service.modifySnapshot(UUID.fromString("332a90fb-c02f-4b35-b273-b66eab7e6140"),"modified_memo");
-       assertTrue(newshot.getMemo().equals("modified_memo"));
+        assertTrue(newshot.getMemo().equals("modified_memo"));
     
     }
     
     
     @Test
     void redis_단건_삭제(){
-        
-        //[068d718b-4a80-4bb5-96bf-fec395e1d5b3, a8296418-127a-4839-80e7-6697f730cc5a, c95224ea-b7cc-4ded-b23d-09c5670f5145, 99f6168a-1bf0-46b2-bb70-dad04fdc0421, 030434af-2eab-4b95-af6e-1abbc872d282, ebe37cef-4795-41e7-8b16-7fa169728898, 3412bd33-950c-4c68-9db6-a955987e63a3, bf937828-49fa-4a3d-ae83-8b6256939ae3, ed9365b1-9899-4c28-b7cc-f6c83354fb30, f4351de8-8719-49f4-99c5-b2a2989057df, 10361e27-794e-4dcc-b17d-4ebccdedb146, 332a90fb-c02f-4b35-b273-b66eab7e6140, 513fb53d-b6e1-4bbd-bb59-3067150e15dc, b3477404-557e-44c0-859f-201912c78d33, 4c3fef4a-2e04-4e1b-86ca-fff34b8e67bc, 348cb38a-6640-4a72-a7cd-9c769ec1f6e1, 740def97-106b-4446-9632-df74b03bbc06]
-    
+
         assertTrue(service.getSnapshot(UUID.fromString("068d718b-4a80-4bb5-96bf-fec395e1d5b3"))!= null);
         service.deleteSnapshot(UUID.fromString("068d718b-4a80-4bb5-96bf-fec395e1d5b3"));
         assertTrue(service.getSnapshot(UUID.fromString("068d718b-4a80-4bb5-96bf-fec395e1d5b3"))== null);


### PR DESCRIPTION
## 작업 목록
<details> <summary>스냅샷 기능 구현</summary>

- 생성(저장)
- 다건/단건 조회
- 수정 (메모 수정)
- 스냅샷 삭제

</details>


## 논의 사항
### 1. entity에 대한 직접적인 setter 적용 논의
- 우리가 저번에 생각을 못했던 게, 이거는 jpa를 사용하지 않고 redistemplate을 통해서 그냥 in memory에 작업하는 방식이얌,
- 문제는 이렇게 되어버리니까 막 id 자동 생성도 안 되고, jpa auditing 기능도 못 쓰는 것 같아
- 일단 id값은 uuid random하게 생성해서 넣어줬고, created time에는 create 서비스 안에서 now 호출해서 넣어주고
- modified time은 modify 서비스 안에서 now 호출해서 넣어줬는데
- 약간 이렇게 되버리니까 entity에서 setter를 너무 많이 쓴다는 느낌,,,?이 드는데 혹시 수빈쒸는 어떻게 생각하시는지 궁금하구

### 2. 혹시 얘는 baseEntity 상속 안 받게 하는 거 어떻게 생각하는지,,,?
- 아까 1번에서 언급한 거랑 비슷한데, 얘 같은 경우에는 jpa를 안 쓰니까 지금 baseEntity에 있는  @GeneratedValue가 안 먹히는 것 같아,,, 계속 null값으로 나오길래
- 일단 baseEntity 상속 안 받고 얘 안에서 @id 로 선언해서 쓰고 있는데, 혹시 이 부분에 대해서 또 다른 의견이 있는지 궁금해!
