### PR TITLE
[Resolves #17] 코드 컴파일(실행) 기능 구현

### DIFF
--- a/src/main/java/oncoding/concoder/ConcoderApplication.java
+++ b/src/main/java/oncoding/concoder/ConcoderApplication.java
@@ -1,10 +1,7 @@
 package oncoding.concoder;
 
-import oncoding.concoder.service.ProblemService;
-import org.springframework.boot.LazyInitializationExcludeFilter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
@@ -17,8 +14,4 @@ public class ConcoderApplication {
         SpringApplication.run(ConcoderApplication.class, args);
     }
 
-    @Bean
-    LazyInitializationExcludeFilter lazyInitializationExcludeFilter() {
-        return LazyInitializationExcludeFilter.forBeanTypes(ProblemService.class);
-    }
 }

--- a/src/main/java/oncoding/concoder/config/AsyncConfig.java
+++ b/src/main/java/oncoding/concoder/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package oncoding.concoder.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean(name = "taskExecutor")
+    public TaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(5);
+        taskExecutor.setMaxPoolSize(10);
+        taskExecutor.setQueueCapacity(50);
+        taskExecutor.setAwaitTerminationSeconds(30);
+        taskExecutor.setThreadNamePrefix("compile");
+        taskExecutor.initialize();
+        return taskExecutor;
+    }
+
+}

--- a/src/main/java/oncoding/concoder/config/AsyncConfig.java
+++ b/src/main/java/oncoding/concoder/config/AsyncConfig.java
@@ -15,7 +15,6 @@ public class AsyncConfig {
         taskExecutor.setCorePoolSize(5);
         taskExecutor.setMaxPoolSize(10);
         taskExecutor.setQueueCapacity(50);
-        taskExecutor.setAwaitTerminationSeconds(30);
         taskExecutor.setThreadNamePrefix("compile");
         taskExecutor.initialize();
         return taskExecutor;

--- a/src/main/java/oncoding/concoder/controller/CompileController.java
+++ b/src/main/java/oncoding/concoder/controller/CompileController.java
@@ -15,12 +15,9 @@ public class CompileController {
     private final CompileService compileService;
 
     @PostMapping("")
-    public String test(@RequestBody CompileDTO.CreateRequest req) {
+    public String test(@RequestBody String code) {
         try {
-            for (int i = 0; i<req.getInputs().size(); i++) {
-                compileService.run(req.getCode(), req.getInputs().get(i));
-            }
-            return "ok";
+            return compileService.run(code,"").get();
         }
         catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/oncoding/concoder/controller/CompileController.java
+++ b/src/main/java/oncoding/concoder/controller/CompileController.java
@@ -1,0 +1,29 @@
+package oncoding.concoder.controller;
+
+import lombok.RequiredArgsConstructor;
+import oncoding.concoder.service.CompileService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/compile")
+@RequiredArgsConstructor
+public class CompileController {
+    private final CompileService compileService;
+
+    @PostMapping("")
+    public String test(@RequestBody String code) {
+        try {
+            return compileService.run(code);
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            return e.getStackTrace().toString();
+        }
+    }
+
+}

--- a/src/main/java/oncoding/concoder/controller/CompileController.java
+++ b/src/main/java/oncoding/concoder/controller/CompileController.java
@@ -17,8 +17,9 @@ public class CompileController {
     @PostMapping("")
     public String test(@RequestBody CompileDTO.CreateRequest req) {
         try {
-            for (int i = 0; i<10; i++) // TODO : 테스트 케이스 받아서 테스트 케이스마다 실행
-                compileService.run(req.getCode(), req.getInput());
+            for (int i = 0; i<req.getInputs().size(); i++) {
+                compileService.run(req.getCode(), req.getInputs().get(i));
+            }
             return "ok";
         }
         catch (Exception e) {

--- a/src/main/java/oncoding/concoder/controller/CompileController.java
+++ b/src/main/java/oncoding/concoder/controller/CompileController.java
@@ -1,12 +1,11 @@
 package oncoding.concoder.controller;
 
 import lombok.RequiredArgsConstructor;
+import oncoding.concoder.dto.CompileDTO;
 import oncoding.concoder.service.CompileService;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -16,10 +15,10 @@ public class CompileController {
     private final CompileService compileService;
 
     @PostMapping("")
-    public String test(@RequestBody String code) {
+    public String test(@RequestBody CompileDTO.CreateRequest req) {
         try {
             for (int i = 0; i<10; i++) // TODO : 테스트 케이스 받아서 테스트 케이스마다 실행
-                compileService.run(code);
+                compileService.run(req.getCode(), req.getInput());
             return "ok";
         }
         catch (Exception e) {

--- a/src/main/java/oncoding/concoder/controller/CompileController.java
+++ b/src/main/java/oncoding/concoder/controller/CompileController.java
@@ -18,7 +18,9 @@ public class CompileController {
     @PostMapping("")
     public String test(@RequestBody String code) {
         try {
-            return compileService.run(code);
+            for (int i = 0; i<10; i++) // TODO : 테스트 케이스 받아서 테스트 케이스마다 실행
+                compileService.run(code);
+            return "ok";
         }
         catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/oncoding/concoder/dto/CompileDTO.java
+++ b/src/main/java/oncoding/concoder/dto/CompileDTO.java
@@ -1,5 +1,6 @@
 package oncoding.concoder.dto;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,7 +13,7 @@ public class CompileDTO {
     @AllArgsConstructor
     public static class CreateRequest {
         private String code;
-        private String input;
+        private List<String> inputs;
     }
 
 }

--- a/src/main/java/oncoding/concoder/dto/CompileDTO.java
+++ b/src/main/java/oncoding/concoder/dto/CompileDTO.java
@@ -1,0 +1,18 @@
+package oncoding.concoder.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+public class CompileDTO {
+    @Getter
+    @Setter
+    @ToString
+    @AllArgsConstructor
+    public static class CreateRequest {
+        private String code;
+        private String input;
+    }
+
+}

--- a/src/main/java/oncoding/concoder/model/Problem.java
+++ b/src/main/java/oncoding/concoder/model/Problem.java
@@ -30,6 +30,12 @@ public class Problem extends JpaBaseEntity {
     @Column
     private Float averageTries;
 
+    @Column
+    private Integer timeLimit;
+
+    @Column
+    private Integer memoryLimit;
+
     @Column(columnDefinition = "MEDIUMTEXT")
     @NotNull
     private String description;
@@ -47,13 +53,17 @@ public class Problem extends JpaBaseEntity {
     private List<ProblemCategory> categories = new ArrayList<>();
 
     @Builder
-    public Problem(Integer number, String title, String description, String input, String output, Float averageTries, Level level, List<ProblemCategory> categories) {
+    public Problem(Integer number, String title, Integer timeLimit, Integer memoryLimit, Float averageTries,
+        String description, String input, String output,
+        Level level, List<ProblemCategory> categories) {
         this.number = number;
         this.title = title;
         this.description = description;
         this.input = input;
         this.output = output;
         this.averageTries = averageTries;
+        this.timeLimit = timeLimit;
+        this.memoryLimit = memoryLimit;
         this.level = level;
         this.categories = categories;
     }

--- a/src/main/java/oncoding/concoder/service/CompileService.java
+++ b/src/main/java/oncoding/concoder/service/CompileService.java
@@ -50,17 +50,15 @@ public class CompileService {
     public String getOutput(BufferedReader bufferedReader, int exitCode, long time) throws IOException {
         StringBuilder sb = new StringBuilder();
         String line;
+        boolean first = true;
         while ((line = bufferedReader.readLine()) != null) {
+            if (first) first = false;
+            else sb.append("\n");
             sb.append(line);
-            sb.append("\n");
         }
 
-        if (exitCode!=0) {
-            log.info("run failed with exit code " + exitCode + " time : " + TimeUnit.MILLISECONDS.convert(time, TimeUnit.NANOSECONDS));
-        }
-        else {
-            log.info("run success with exit code "+ exitCode + " time: " + TimeUnit.MILLISECONDS.convert(time, TimeUnit.NANOSECONDS));
-        }
+        String result = exitCode!=0 ? "failed" : "success";
+        log.info("run " + result + " with exit code " + exitCode + " time: " + TimeUnit.MILLISECONDS.convert(time, TimeUnit.NANOSECONDS)+"ms");
         return sb.toString();
     }
 

--- a/src/main/java/oncoding/concoder/service/CompileService.java
+++ b/src/main/java/oncoding/concoder/service/CompileService.java
@@ -31,7 +31,7 @@ public class CompileService {
 
         FileWriter fw = new FileWriter(file);
         try (BufferedWriter writer = new BufferedWriter(fw)) {
-            writer.write(content);
+            writer.write(content.substring(1, content.length()-1));
         }
     }
 

--- a/src/main/java/oncoding/concoder/service/CompileService.java
+++ b/src/main/java/oncoding/concoder/service/CompileService.java
@@ -1,0 +1,76 @@
+package oncoding.concoder.service;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CompileService {
+
+    public void writeFile(String name, String content) throws IOException {
+        File file = new File(Paths.get(String.format("%s.py", name)).toString());
+
+        FileWriter fw = new FileWriter(file);
+        try (BufferedWriter writer = new BufferedWriter(fw)) {
+            writer.write(content.substring(1, content.length()-1));
+        }
+    }
+
+    /*
+    파일 존재할 경우 : 삭제 (삭제 제대로 처리되지 않을 경우 print)
+    파일 존재하지 않을 경우 : 무시
+    */
+    public void deleteFile(String name) {
+        File file = new File(Paths.get(String.format("%s.py", name)).toString());
+
+        if (!file.exists()) return;
+        if (file.delete()) return;
+        System.out.println("Error : file "+ Paths.get(String.format("file %s.py", name)).toString() +" not deleted!");
+    }
+
+    public String getOutput(BufferedReader bufferedReader, boolean success) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        String line;
+        while ((line = bufferedReader.readLine()) != null) {
+            sb.append(line);
+            sb.append("\n");
+        }
+
+        if (!success) {
+            System.out.println("비정상 종료");
+        }
+        else {
+            System.out.println("정상 종료");
+        }
+        return sb.toString();
+    }
+
+    public String run(String code) throws IOException, InterruptedException {
+        String random = UUID.randomUUID().toString();
+        try {
+            writeFile(random, code);
+
+            ProcessBuilder processBuilder = new ProcessBuilder("python3",
+                Paths.get(String.format("%s.py", random)).toString());
+            Process process = processBuilder.start();
+            ProcessHandle.Info processInfo = process.info();
+            int exitCode = process.waitFor();
+
+            BufferedReader br;
+            br = exitCode!=0 ? new BufferedReader(new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8))
+                : new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
+            return getOutput(br, exitCode==0);
+        }
+        finally {
+            deleteFile(random);
+        }
+
+    }
+}

--- a/src/main/java/oncoding/concoder/service/CrawlingService.java
+++ b/src/main/java/oncoding/concoder/service/CrawlingService.java
@@ -62,6 +62,11 @@ public class CrawlingService {
         Elements outputs = document.select("#problem_output");
         content.put("output", joinElementsText(outputs, "\n"));
 
+        Element time = document.select("#problem-info > tbody > tr > td:nth-child(1)").get(0);
+        Element memory = document.select("#problem-info > tbody > tr > td:nth-child(2)").get(0);
+        content.put("timeLimit", time.text());
+        content.put("memoryLimit", memory.text());
+
         return content;
     }
 

--- a/src/main/java/oncoding/concoder/service/ProblemService.java
+++ b/src/main/java/oncoding/concoder/service/ProblemService.java
@@ -71,6 +71,8 @@ public class ProblemService {
                 .output(content.get("output"))
                 .level(levelMap.get(rawProblem.getLevel()))
                 .averageTries(rawProblem.getAverageTries())
+                .timeLimit(Integer.parseInt(content.get("timeLimit").replaceAll("[^\\d]*", "")))
+                .memoryLimit(Integer.parseInt(content.get("memoryLimit").replaceAll("[^\\d]*", "")))
                 .build();
             problems.add(problem);
         }

--- a/src/test/java/oncoding/concoder/service/CompileServiceTest.java
+++ b/src/test/java/oncoding/concoder/service/CompileServiceTest.java
@@ -1,26 +1,81 @@
 package oncoding.concoder.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
+@SpringBootTest(classes = {CompileService.class})
+@ActiveProfiles("test")
 class CompileServiceTest {
     @Autowired
     private CompileService compileService;
 
+    private final int THREAD_TIMEOUT_SECONDS = 10; // task timeout 설정 시간 (초)
+
     @Test
-    void async_task_executor_실행() {
-        for (int i = 0; i<20; i++){
-            try {
-                compileService.run("print('hello world')");
-            }
-            catch (Exception e) {
-                fail();
-            }
+    void task_비동기_처리() {
+        // given
+        String text = "hello world";
+        String pythonCode = "print(\""+text+"\", end=\"\")";
+
+        // when
+        String result = "";
+        Future<String> future = null;
+        try {
+           future = compileService.run(pythonCode, "");
+           result = future.get();
         }
+        catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+
+        // then
+        assertThat(result).isEqualTo(text);
+        assertThat(future).isNotNull();
+        assertThat(future).isDone();
+        assertThat(future).succeedsWithin(THREAD_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void 특정_시간을_넘어가는_task_timeout_처리() {
+        // given
+        String timeoutCode = "while True:\n" + "    a = 1;";
+
+        // when, then
+        assertThatThrownBy(()-> compileService.run(timeoutCode, "").get())
+                .isInstanceOf(InterruptedException.class);
+    }
+
+    @Test
+    void 에러_발생하는_task_처리() {
+        // given
+        String errorCode = "print(";
+
+        // when
+        String result = "";
+        Future<String> future = null;
+        try {
+            future = compileService.run(errorCode, "");
+            result = future.get();
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+        // then
+        assertThat(result).contains("Error"); // Error 내용 반환
+        assertThat(future).isNotNull();
+        assertThat(future).isDone(); // Task 자체는 시간 내 완료
+        assertThat(future).succeedsWithin(THREAD_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     }
 
 }

--- a/src/test/java/oncoding/concoder/service/CompileServiceTest.java
+++ b/src/test/java/oncoding/concoder/service/CompileServiceTest.java
@@ -1,0 +1,26 @@
+package oncoding.concoder.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CompileServiceTest {
+    @Autowired
+    private CompileService compileService;
+
+    @Test
+    void async_task_executor_실행() {
+        for (int i = 0; i<20; i++){
+            try {
+                compileService.run("print('hello world')");
+            }
+            catch (Exception e) {
+                fail();
+            }
+        }
+    }
+
+}

--- a/src/test/java/oncoding/concoder/service/CompileServiceTest.java
+++ b/src/test/java/oncoding/concoder/service/CompileServiceTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -78,4 +80,42 @@ class CompileServiceTest {
         assertThat(future).succeedsWithin(THREAD_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     }
 
+    @Test
+    void 인풋_받는_Task_실행() {
+        // given
+        String inputCode = "a=int(input())\n"
+            +"print(a)\n"
+            +"b=int(input())\n"
+            +"print(b)";
+        List<String> inputs = List.of("5\n15", "7\n21");
+        List<String> expectedResults = List.of("5\n15", "7\n21");
+
+        // when
+        List<String> results = new ArrayList<>();
+        List<Future<String>> futures = new ArrayList<>();
+        try {
+            for (int i = 0; i<inputs.size(); i++) {
+                Future<String> future = compileService.run(inputCode, inputs.get(i));
+                futures.add(future);
+            }
+            for (int i = 0; i<inputs.size(); i++) {
+                results.add(futures.get(i).get());
+            }
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+        // then
+        assertThat(results.size()).isEqualTo(inputs.size()); // Error 내용 반환
+        for (int i = 0; i<inputs.size(); i++) {
+            Future<String> future = futures.get(i);
+            assertThat(future).isNotNull();
+            assertThat(future).isDone(); // Task 자체는 시간 내 완료
+            assertThat(future).succeedsWithin(THREAD_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            String result = results.get(i);
+            assertThat(result).isEqualTo(expectedResults.get(i));
+        }
+
+    }
 }


### PR DESCRIPTION
## 작업 목록
<details> <summary>코드 컴파일(실행) 기능 구현</summary>

- 사용자로부터 코드 받아서 실행 처리
- 실행 결과 또는 오류 정보 결과값으로 처리
- 실행 정보 측정 (시간)
- 일정 시간 이상으로 실행시 타임아웃처리
- 비동기, 스레드 처리
- 사용자로부터 여러 인풋 받아서 처리
</details>


## 논의 사항
- 파이썬 기준으로 구현되었습니다! 
   해당 기능 정상 작동하기 위해서는 배포 서버에 python3의 설치가 되어있어 
   🚨`python3 <파일이름>.py` 명령어의 실행이 가능해야합니다! 🚨

- 무한정 실행되는 코드의 실행이 서버에서 무한정으로 돌아가는 것을 방지하기 위해서
   타이머를 이용해서 일정 시간 (현재는 `10초`) 이후 강제 종료되도록 했습니다!

- API 요청은 다음과 같은 DTO를 받아서 실행됩니당~
  (결과 반환까지 대기하지 않고 ok만 반환 이후 비동기적으로 처리하는 것에 유의해주세요~)
  <img width="1008" alt="스크린샷 2022-11-20 오후 9 20 54" src="https://user-images.githubusercontent.com/69030160/202901573-08e2e722-a91a-4ef1-b381-1acbd3f61a95.png">

- 테스트케이스들을 문자열 배열로 받으면 테스트케이스마다  ThreadTaskExecutor를 이용해
  `CompileService.run(String code, String input)`을 Task로 실행합니다. (스레드 풀 내의 스레드 작업 수행)
  각각의 테스트케이스는 백준 방식으로 사용자가 콘솔에 입력하는 식으로 생각하면 될 거 같습니다 😄

- `CompileService.run(String code, String input)`의 실행 과정은 다음과 같습니다.
  - 실행시 다른 스레드를 사용해서 특정 시간 (타임아웃 시간) 이후에 현재 스레드에 interrupt(스레드 중지 위해서) 거는 TimerTask를 실행
  - 받은 코드를 python3 명령어로 실행하기 위해서 `<랜덤 uuid>.py` 파일로 작성
  - ProcessBuilder를 통해서 OS 단의 프로세스 생성 및 시작 (파이썬 명령어 실행할 프로세스)
  - 만들어진 프로세스에 input 작성
  - 프로세스 종료까지 대기, 종료시 소요 시간 측정
  - 프로세스의 아웃풋 읽어서 결과값으로 처리 (현재 String으로 만들어놓기만 했습니다! 소켓 기능 추가되면 소켓 통해서 해당하는 워크스페이스에 테스트케이스의 id(input의 id)와 함께뿌려줄 예정입니다!)
  - 만들었던 코드 파일 삭제

- 스레드(Task) 실행시와 스레드 실행 결과로 성공/실패/타임아웃을 로그로 기록하도록 했습니다!
  - 실행 성공
    <img width="1079" alt="스크린샷 2022-11-20 오후 7 37 42" src="https://user-images.githubusercontent.com/69030160/202901678-bc76ef40-32ef-4e7d-bc9d-10a8e6b1441a.png">

  - 실행 실패 (코드 에러)
    <img width="1070" alt="스크린샷 2022-11-20 오후 7 40 49" src="https://user-images.githubusercontent.com/69030160/202902048-35bd8d28-7773-41bd-a75f-5b0c7c0b5b70.png">

  - 실행 타임아웃
    <img width="1054" alt="스크린샷 2022-11-20 오후 7 39 42" src="https://user-images.githubusercontent.com/69030160/202901687-d2756367-3be6-4afd-a129-ea5e1560a384.png">

- 현재는 일단 한번에 `5`개의 스레드 (테스크 큐가 꽉찼을 경우 `10`개의 스레드), 
  테스크 쌓아놓을 큐의 크기는 `50`으로 해놨는데 큐의 크기는 더 늘려도 될 것 같기두합니당! (테스트케이스마다 테스크로 분리되니까)
