### PR TITLE
[Resolves #89] OpenVidu로 WebRTC 구조 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
 
     //jsoup
     implementation 'org.jsoup:jsoup:1.14.2'
+
+    //OpenVidu
+    implementation 'io.openvidu:openvidu-java-client:2.26.0'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     depends_on:
       - mysql
       - redis
+      - openvidu
     deploy:
       resources:
         limits:
@@ -42,6 +43,15 @@ services:
       resources:
         limits:
           memory: 200M
+
+  openvidu:
+    restart: always
+    container_name: concoder-openvidu
+    image: openvidu/openvidu-dev:2.27.0
+    ports:
+      - 4443:4443
+    environment:
+      OPENVIDU_SECRET: ${OPENVIDU_SECRET}
 
 volumes:
   concoder-volume:

--- a/src/main/java/oncoding/concoder/controller/VideoRoomController.java
+++ b/src/main/java/oncoding/concoder/controller/VideoRoomController.java
@@ -1,6 +1,15 @@
 package oncoding.concoder.controller;
 
 import java.util.List;
+import java.util.Map;
+
+import io.openvidu.java.client.Connection;
+import io.openvidu.java.client.ConnectionProperties;
+import io.openvidu.java.client.OpenVidu;
+import io.openvidu.java.client.OpenViduHttpException;
+import io.openvidu.java.client.OpenViduJavaClientException;
+import io.openvidu.java.client.Session;
+import io.openvidu.java.client.SessionProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import oncoding.concoder.dto.ChatDTO.UserAndRoomResponse;
@@ -8,7 +17,9 @@ import oncoding.concoder.dto.ChatDTO.ExitResponse;
 import oncoding.concoder.dto.ChatDTO.UserResponse;
 import oncoding.concoder.service.ChattingService;
 import org.json.simple.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -16,11 +27,14 @@ import org.springframework.messaging.simp.SimpAttributesContextHolder;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.socket.messaging.SessionConnectEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import javax.annotation.PostConstruct;
 
 @Slf4j
 @RestController
@@ -29,6 +43,16 @@ public class VideoRoomController {
 
   private final ChattingService chattingService;
   private final SimpMessagingTemplate template;
+
+  @Value("${OPENVIDU_SECRET}")
+  private String OPENVIDU_SECRET;
+
+  private OpenVidu openvidu;
+
+  @PostConstruct
+  public void init() {
+    this.openvidu = new OpenVidu("http://localhost:4443/", OPENVIDU_SECRET);
+  }
 
   @MessageMapping("/video/chat/{roomId}")
   public void chat(@DestinationVariable final String roomId, JSONObject ob) {
@@ -94,6 +118,35 @@ public class VideoRoomController {
   }
 
 
+  /**
+   * @param params The Session properties
+   * @return The Session ID
+   */
+  @PostMapping("/sessions")
+  public ResponseEntity<String> initializeSession(@RequestBody(required = false) Map<String, Object> params)
+          throws OpenViduJavaClientException, OpenViduHttpException {
+    SessionProperties properties = SessionProperties.fromJson(params).build();
+    Session session = openvidu.createSession(properties);
+    return new ResponseEntity<>(session.getSessionId(), HttpStatus.OK);
+  }
+
+  /**
+   * @param sessionId The Session in which to create the Connection
+   * @param params    The Connection properties
+   * @return The Token associated to the Connection
+   */
+  @PostMapping("/sessions/{sessionId}/connections")
+  public ResponseEntity<String> createConnection(@PathVariable("sessionId") String sessionId,
+                                                 @RequestBody(required = false) Map<String, Object> params)
+          throws OpenViduJavaClientException, OpenViduHttpException {
+    Session session = openvidu.getActiveSession(sessionId);
+    if (session == null) {
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
+    ConnectionProperties properties = ConnectionProperties.fromJson(params).build();
+    Connection connection = session.createConnection(properties);
+    return new ResponseEntity<>(connection.getToken(), HttpStatus.OK);
+  }
 
 
   // caller의 정보를 다른 callee들에게 쏴준다.


### PR DESCRIPTION
[#89](https://github.com/KHUCapston-concoder/Backend/issues/89)
## 작업 목록
### `VideoRoomController`
- OpenVidu에서 참가자들이 들어올 수 있는 가상의 방인 Session을 초기화하는 `initializeSession` 추가
- Session에 참가하는 사람이 생길 때, Connection을 생성하고 해당하는 Token을 반환하는 `createConnection` 추가
- docker-compose.yml에 openvidu 서비스를 추가

<details> <summary>해야할 일</summary>

- 프론트에 SFU 적용한 뒤
- OpenVidu로 대체하여 안쓰게 된 기능들 삭제하기

</details>